### PR TITLE
fix(cz): repeating lines & color issue when using cz

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
+
+if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then exec </dev/tty >/dev/tty 2>&1; fi
+
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,6 @@
 #!/bin/sh
+if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then exec </dev/tty >/dev/tty 2>&1; fi
+
 . "$(dirname "$0")/_/husky.sh"
 
 exec < /dev/tty && npx git-cz --hook || true


### PR DESCRIPTION
# The Problem
So when using the commitizen's utility for doing the lint-staged and pre-commit activities, for some reason in my git bash it's broken. Especially when I type the commit details it gets annoying as it duplicates the line everytime i type a character (see images below). So I googled and found a fix in this [open issue](https://github.com/commitizen/cz-cli/issues/709#issuecomment-1919432815). This fixes the repeating line issue and also adds beautiful colors & icons in lint-staged step.

If you guys have this same problem try pulling this branch, do some commits and see if it's working. Try doing it even if you don't have this issue to ensure it doesn't break anything :)

---
### Before
![image](https://github.com/Gukkey/project-forum/assets/63956643/8005d9af-8096-437b-bee3-3d762ecec598)
![image](https://github.com/Gukkey/project-forum/assets/63956643/c2e2941d-e5de-47af-bb0d-faf2ab229a79)

---

### After
![image](https://github.com/Gukkey/project-forum/assets/63956643/78813e5b-0bb3-4ba8-8a3c-65381145a63c)


