### PR TITLE
Prevent hot reloading from creating new instances of PrismaClient

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,14 @@
 import { PrismaClient } from "@prisma/client"
+import { env } from "@projectforum/env"
 
-const prisma = new PrismaClient()
+const prismaClientSingleton = () => {
+  return new PrismaClient({ log: ["error", "info", "warn"] })
+}
 
-export { prisma }
+declare const globalThis: {
+  prismaGlobal: ReturnType<typeof prismaClientSingleton>
+} & typeof global
+
+export const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
+
+if (env.NODE_ENV !== "production") globalThis.prismaGlobal = prisma


### PR DESCRIPTION
Instantiating PrismaClient in the [recommended](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections#prevent-hot-reloading-from-creating-new-instances-of-prismaclient) way. 